### PR TITLE
Fix wrong number of arguments error

### DIFF
--- a/Casks/Xpipe.rb
+++ b/Casks/Xpipe.rb
@@ -15,7 +15,7 @@ cask "xpipe" do
     strategy :github_latest
   end
 
-  depends_on "util-linux"
+  depends_on formula: "util-linux"
 
   pkg "xpipe-installer-macos-#{arch}.pkg"
   uninstall script:  {


### PR DESCRIPTION
Recently cask was updated with "depends_on" added and now it broken. 

Neither 
`brew install --cask xpipe-io/tap/xpipe` or 
`brew tap xpipe-io/tap && brew install --cask xpipe` or 
`brew tap xpipe-io/homebrew-tap && brew install --cask xpipe` not working.

<details>
  <summary>console output with `--debug` and `--verbose` arguments</summary>

```command
brew install --debug --verbose --cask xpipe-io/tap/xpipe
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapLoader): loading xpipe-io/tap/xpipe
Warning: Cask 'xpipe' is unreadable: wrong number of arguments (given 1, expected 0)
==> Downloading https://formulae.brew.sh/api/formula.jws.json
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --user-agent Homebrew/4.2.15\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 14.4.1\)\ curl/8.4.0 --header Accept-Language:\ en --fail --remote-time --output /Users/rybakov/Library/Caches/Homebrew/api/formula.jws.json --location --time-cond /Users/rybakov/Library/Caches/Homebrew/api/formula.jws.json --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.2.15\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 14.4.1\)\ curl/8.4.0 --header Accept-Language:\ en --fail --compressed --speed-limit 100 --speed-time 5 https://formulae.brew.sh/api/formula.jws.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromAPILoader): loading xpipe
==> Searching for similarly named casks...
==> Downloading https://formulae.brew.sh/api/cask.jws.json
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --user-agent Homebrew/4.2.15\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 14.4.1\)\ curl/8.4.0 --header Accept-Language:\ en --fail --remote-time --output /Users/rybakov/Library/Caches/Homebrew/api/cask.jws.json --location --time-cond /Users/rybakov/Library/Caches/Homebrew/api/cask.jws.json --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.2.15\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 14.4.1\)\ curl/8.4.0 --header Accept-Language:\ en --fail --compressed --speed-limit 100 --speed-time 5 https://formulae.brew.sh/api/cask.jws.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::NullLoader): loading xpipe-io/tap/Xpipe
Error: Cask 'xpipe' is unavailable: No Cask with this name exists.
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:507:in `load'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:516:in `load'
/opt/homebrew/Library/Homebrew/search.rb:98:in `block in search_casks'
/opt/homebrew/Library/Homebrew/search.rb:97:in `map'
/opt/homebrew/Library/Homebrew/search.rb:97:in `search_casks'
/opt/homebrew/Library/Homebrew/search.rb:117:in `search_names'
/opt/homebrew/Library/Homebrew/cmd/install.rb:383:in `rescue in install'
/opt/homebrew/Library/Homebrew/cmd/install.rb:166:in `install'
/opt/homebrew/Library/Homebrew/brew.rb:91:in `public_send'
/opt/homebrew/Library/Homebrew/brew.rb:91:in `<main>'
```

</details>

(if only there was more descriptive error)

According to official cask [Cask-Cookbook](https://docs.brew.sh/Cask-Cookbook#stanza-depends_on)

what we should do is to add `formula:` directive in front of "util-linux" and do the same thing for each formula or cask.

And installing it from fork with this changes confirms that this is the case:

<details>
  <summary>Success install</summary>

```command
brew install --cask siberianlove/homebrew-tap/xpipe
==> Downloading https://github.com/xpipe-io/xpipe/releases/download/8.6/xpipe-installer-macos-arm64.pkg
Already downloaded: /Users/siberianlove/Library/Caches/Homebrew/downloads/1e241454861e645610e5ac9bca6593198f9b0cee6a3e52896080e4fe618067e2--xpipe-installer-macos-arm64.pkg
Warning: No checksum defined for cask 'xpipe', skipping verification.
==> Installing dependencies: util-linux
==> Downloading https://ghcr.io/v2/homebrew/core/util-linux/manifests/2.39.3-1
Already downloaded: /Users/siberianlove/Library/Caches/Homebrew/downloads/811c2708e034b96b17e1a032fe2265d27e09e0deba568a4bbb1f39b6caef4510--util-linux-2.39.3-1.bottle_manifest.json
==> Fetching util-linux
==> Downloading https://ghcr.io/v2/homebrew/core/util-linux/blobs/sha256:c0fe29bd7ce098ba80b119b4a6b37c16255e9a028724f91ca64efb5259fc9a34
Already downloaded: /Users/siberianlove/Library/Caches/Homebrew/downloads/dd16d8399cba5d9db827238251d8b357ae35b07d05991cc25be9a9c95d7d48c3--util-linux--2.39.3.arm64_sonoma.bottle.1.tar.gz
==> Installing util-linux
==> Pouring util-linux--2.39.3.arm64_sonoma.bottle.1.tar.gz
🍺  /opt/homebrew/Cellar/util-linux/2.39.3: 229 files, 16.3MB
==> Installing Cask xpipe
==> Running installer for xpipe with sudo; the password may be necessary.
installer: Package name is XPipe
installer: Installing at base path /
installer: The install was successful.
🍺  xpipe was successfully installed!
```

</details>

It's kind of confusing that the [Formula-Cookbook](https://docs.brew.sh/Formula-Cookbook#specifying-other-formulae-as-dependencies) is different syntax.

Thanks for such a great tool by the way!